### PR TITLE
Add a clarification for sandbox users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To identify the user the Service Provider (your website) redirects the user to t
 
 ### Sandbox users
 
-OP Identity Service Provider sandbox uses fixed credentials (API key / Client ID). __See section 13__ for 
+OP Identity Service Provider sandbox uses fixed credentials (API key / Client ID). __See section 13__.
 
 Table of contents:
 1. Definitions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ OP Identification Service Broker allows Service Providers to implement strong el
 
 To identify the user the Service Provider (your website) redirects the user to the Identification Service Broker (OP) with an authorization request. The user chooses the Identity Provider (a bank or Mobile ID) and is redirected there where he/she authenticates with his/her own credentials. OP will process the authentication result, and return the user to your website with verified information about the identity of the user.
 
-__Sandbox users__: ISB sandbox uses fixed Client IDs / API keys. __See section 13__.
+### Sandbox users
+
+OP Identity Service Provider sandbox uses fixed credentials (API key / Client ID). __See section 13__ for 
 
 Table of contents:
 1. Definitions

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To identify the user the Service Provider (your website) redirects the user to t
 
 ### Sandbox users
 
-OP Identity Service Provider sandbox uses fixed credentials (API key / Client ID). __See section 13__.
+OP Identity Service Provider does not require registration and uses fixed credentials (Client ID & encryption keys). __See section 13__.
 
 Table of contents:
 1. Definitions

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ OP Identification Service Broker allows Service Providers to implement strong el
 
 To identify the user the Service Provider (your website) redirects the user to the Identification Service Broker (OP) with an authorization request. The user chooses the Identity Provider (a bank or Mobile ID) and is redirected there where he/she authenticates with his/her own credentials. OP will process the authentication result, and return the user to your website with verified information about the identity of the user.
 
+__Sandbox users__: ISB sandbox uses fixed Client IDs / API keys. __See section 13__.
+
 Table of contents:
 1. Definitions
 2. Prerequisites


### PR DESCRIPTION
Mentioning sandbox credentials at the top of the page is helpful towards developers. Currently, developers may scan the top of the page and not realize that registration on OP Developer is not required for ISB sandbox.